### PR TITLE
Fix "Trying to insert a block on non-empty cell" error from Contextual Menu

### DIFF
--- a/simulatorCore/src/gui/openglViewer.cpp
+++ b/simulatorCore/src/gui/openglViewer.cpp
@@ -264,7 +264,10 @@ void GlutContext::mouseFunc(int button,int state,int x,int y) {
             GlBlock *slct=BaseSimulator::getWorld()->getselectedGlBlock();
             // unselect current if exists
             if (slct) slct->toggleHighlight();
-            // set n-1 block selected block (no selected block if n=0
+            //hide context menu if showed
+            if (popupMenu && popupMenu->isVisible) popupMenu->show(false);
+            if (popupSubMenu && popupSubMenu->isVisible) popupSubMenu->show(false);
+            // set n-1 block select->d block (no selected block if n=0
             if (n) {
                 GlBlock *glB = BaseSimulator::getWorld()->setselectedGlBlock(n);
                 glB->toggleHighlight();


### PR DESCRIPTION
From https://github.com/ProgrammableMatterProject/VisibleSim/issues/4
Hello!
I have created pull request to resolve the issue I mentioned in the above issue.
The fix is to close the context menu when you select another part of the page while the context menu is open.
Could you check it?
