### PR TITLE
Fix to use visualtag in exportWorld

### DIFF
--- a/simulatorCore/src/utils/configExporter.cpp
+++ b/simulatorCore/src/utils/configExporter.cpp
@@ -149,7 +149,7 @@ void ConfigExporter::exportWorld() {
     worldElt = new TiXmlElement("world");
     worldElt->SetAttribute("gridSize", toXmlAttribute(world->lattice->gridSize));
     if (GlutContext::GUIisEnabled) {
-        worldElt->SetAttribute("windowSize",
+        worldElt->SetAttribute("visual",
                                toXmlAttribute(GlutContext::screenWidth, GlutContext::screenHeight));
     }
 


### PR DESCRIPTION
Hi!
A windowSize tag in config.xml seems to be deprecated so I fixed to use visual tag when generating config file with save function in GUI context menu.
Could you check it?

* Generated config file(before)
```
<?xml version="1.0" standalone="no" ?>
<world gridSize="5,5,6" windowSize="1280,720">
    <camera target="25,20,10" directionSpherical="0,30,100" angle="30.000000" near="1.000000" far="300.000000" />
    <spotlight target="25,25,0" directionSpherical="-35,40,150" angle="45.000000" />
    <blockList blockSize="10,10,10">
        <block position="0,0,0" color="128,128,64" orientation="0" />
        <block position="1,0,0" color="128,128,64" orientation="0" />
        <block position="2,0,0" color="128,128,64" orientation="0" />
        <block position="3,0,0" color="128,128,64" orientation="0" />
        <block position="0,1,0" color="128,128,64" orientation="0" />
        <block position="1,1,0" color="128,128,64" orientation="0" />
        <block position="2,1,0" color="128,128,64" orientation="0" />
        <block position="3,1,0" color="128,128,64" orientation="0" />
        <block position="0,2,0" color="128,128,64" orientation="0" />
        <block position="1,2,0" color="128,128,64" orientation="0" />
        <block position="2,2,0" color="128,128,64" orientation="0" />
        <block position="3,2,0" color="128,128,64" orientation="0" />
        <block position="0,3,0" color="128,128,64" orientation="0" />
        <block position="1,3,0" color="128,128,64" orientation="0" />
        <block position="2,3,0" color="128,128,64" orientation="0" />
        <block position="3,3,0" color="128,128,64" orientation="0" />
        <block position="0,0,1" color="255,128,128" orientation="0" />
        <block position="1,0,1" color="255,255,64" orientation="0" />
        <block position="2,0,1" color="255,255,64" orientation="0" />
        <block position="1,1,1" color="255,255,64" orientation="0" />
        <block position="2,1,1" color="255,255,64" orientation="0" />
        <block position="2,2,1" color="255,128,128" orientation="0" />
    </blockList>
</world>
```

* Generated config file(after)
```export_16_39_3.xml
<?xml version="1.0" standalone="no" ?>
<world gridSize="5,5,6" visual="1280,720">
    <camera target="25,20,10" directionSpherical="0,30,100" angle="30.000000" near="1.000000" far="300.000000" />
    <spotlight target="25,25,0" directionSpherical="-35,40,150" angle="45.000000" />
    <blockList blockSize="10,10,10">
        <block position="0,0,0" color="128,128,64" orientation="0" />
        <block position="1,0,0" color="128,128,64" orientation="0" />
        <block position="2,0,0" color="128,128,64" orientation="0" />
        <block position="3,0,0" color="128,128,64" orientation="0" />
        <block position="0,1,0" color="128,128,64" orientation="0" />
        <block position="1,1,0" color="128,128,64" orientation="0" />
        <block position="2,1,0" color="128,128,64" orientation="0" />
        <block position="3,1,0" color="128,128,64" orientation="0" />
        <block position="0,2,0" color="128,128,64" orientation="0" />
        <block position="1,2,0" color="128,128,64" orientation="0" />
        <block position="2,2,0" color="128,128,64" orientation="0" />
        <block position="3,2,0" color="128,128,64" orientation="0" />
        <block position="0,3,0" color="128,128,64" orientation="0" />
        <block position="1,3,0" color="128,128,64" orientation="0" />
        <block position="2,3,0" color="128,128,64" orientation="0" />
        <block position="3,3,0" color="128,128,64" orientation="0" />
        <block position="0,0,1" color="255,128,128" orientation="0" />
        <block position="1,0,1" color="255,255,64" orientation="0" />
        <block position="2,0,1" color="255,255,64" orientation="0" />
        <block position="1,1,1" color="255,255,64" orientation="0" />
        <block position="2,1,1" color="255,255,64" orientation="0" />
        <block position="2,2,1" color="255,128,128" orientation="0" />
    </blockList>
</world>

```

Of course after fixed generated file works fine.
```
$ cat export_16_39_3.xml 
<?xml version="1.0" standalone="no" ?>
<world gridSize="5,5,6" visual="1280,720">
*snip*

$ ./C3DRotate -c export_16_39_3.xml 
Starting Catom3D simulation (main) ...
Simulation Seed: 1016950479
initGlut
compilation OK
compilation OK
Shaders initialized.
Scheduler Mode :2
Scheduler Length :1
```
![image](https://user-images.githubusercontent.com/33021308/186610646-a4068fdf-56ce-48a1-90b8-42add47c9e19.png)
