### PR TITLE
Fix illegal module insertion bug

### DIFF
--- a/simulatorCore/src/robots/catoms3D/catoms3DBlock.h
+++ b/simulatorCore/src/robots/catoms3D/catoms3DBlock.h
@@ -41,10 +41,11 @@ const float tabOrientationAngles[12][3] = { {0,0,0}, {180.0f,0.0f,-90.0f}, {-90.
    tabConnectorPositions[i] : coordinates of connector #i
 
 */
-const float tabConnectorPositions[12][3] = { {1,0,0}, {0,1,0}, {0.5,0.5,M_SQRT2_2},
+const float tabConnectorPositions[13][3] = { {1,0,0}, {0,1,0}, {0.5,0.5,M_SQRT2_2},
                                              {-0.5,0.5,M_SQRT2_2},{-0.5,-0.5,M_SQRT2_2},{0.5,-0.5,M_SQRT2_2},
                                              {-1,0,0}, {0,-1,0}, {-0.5,-0.5,-M_SQRT2_2},
-                                             {0.5,-0.5,-M_SQRT2_2},{0.5,0.5,-M_SQRT2_2},{-0.5,0.5,-M_SQRT2_2}};
+                                             {0.5,-0.5,-M_SQRT2_2},{0.5,0.5,-M_SQRT2_2},{-0.5,0.5,-M_SQRT2_2},
+                                             {0,0,0}};
 
 class Catoms3DBlockCode;
 

--- a/simulatorCore/src/robots/catoms3D/catoms3DWorld.cpp
+++ b/simulatorCore/src/robots/catoms3D/catoms3DWorld.cpp
@@ -510,6 +510,7 @@ void Catoms3DWorld::setSelectedFace(int n) {
     else if (name == "Material__78") numSelectedFace = 9;
     else if (name == "Material__69") numSelectedFace = 10;
     else if (name == "Material__70") numSelectedFace = 11;
+    else if (name == "Material__79") numSelectedFace = 12;
     else {
         // cerr << "warning: Unrecognized picking face" << endl;
         numSelectedFace = 13;	// UNDEFINED


### PR DESCRIPTION
# Description
Hi!
I fixed illegal module insertion bug, which inserted by contextual menu poped  up from non-pivot spot.
I added 

* log
```
Thread 1 "myMotionTest" hit Breakpoint 1, Catoms3D::Catoms3DBlock::getNeighborPos (this=0x77ec7940, connectorID=184 '\270', pos=...)
    at robots/catoms3D/catoms3DBlock.cpp:160
160         bool Catoms3DBlock::getNeighborPos(uint8_t connectorID, Cell3DPosition &pos) const {
(gdb) n
161             Vector3D realPos;
(gdb) n
163             Catoms3DWorld *wrl = getWorld();
(gdb) n
164             const Vector3D bs = wrl->lattice->gridScale;
(gdb) n
166             realPos.set(tabConnectorPositions[connectorID], 3, 1);
(gdb) p bs
$1 = {_pt = {10, 10, 10, 0}}
(gdb) n
167             realPos *= bs;
(gdb) p realPos
$2 = {_pt = {0, 0, 0, 1}}
(gdb) n
168             realPos.set(3,1.0); // A vérifier
(gdb) n
169             realPos = ((Catoms3DGlBlock *) ptrGlBlock)->mat * realPos;
(gdb) p realPos
$3 = {_pt = {0, 0, 0, 1}}
(gdb) n
170             if (realPos[2] < 0) return false;
(gdb) p realPos
$4 = {_pt = {20, 20, 10.6066017, 1}}
```

Fixes # (issue)
https://github.com/ProgrammableMatterProject/VisibleSim/issues/13

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [ ] Test B

**Test Configuration**:
* VisibleSim version: https://github.com/ProgrammableMatterProject/VisibleSim/commit/727ea58aecd45a3bf9a4a321bc41c61de5d5aa69

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules